### PR TITLE
Add shared themes folder creation step

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,8 +36,8 @@
             <div id="install">
                 <ul class="commands commands-tooltip">
                     <li>cd /boot/EFI/refind/</li>
-                    <li>mkdir -p themes && cd themes</li>
-                    <li>git clone {{site.github.repository_url}}</li>
+                    <li>mkdir -p themes</li>
+                    <li>git clone {{site.github.repository_url}} themes/{{site.github.repository_name}}</li>
                     <li>echo "include refind-minimal/theme.conf" >> refind.conf</li>
                     <li>systemctl reboot</li>
                 </ul>

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
             <div id="install">
                 <ul class="commands commands-tooltip">
                     <li>cd /boot/EFI/refind/</li>
+                    <li>mkdir -p themes && cd themes</li>
                     <li>git clone {{site.github.repository_url}}</li>
                     <li>echo "include refind-minimal/theme.conf" >> refind.conf</li>
                     <li>systemctl reboot</li>

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
                     <li>cd /boot/EFI/refind/</li>
                     <li>mkdir -p themes</li>
                     <li>git clone {{site.github.repository_url}} themes/{{site.github.repository_name}}</li>
-                    <li>echo "include refind-minimal/theme.conf" >> refind.conf</li>
+                    <li>echo "include themes/refind-minimal/theme.conf" >> refind.conf</li>
                     <li>systemctl reboot</li>
                 </ul>
             </div>


### PR DESCRIPTION
Added step installation instructions to work with a shared theme folder from #25.

The `-p` flag stops `mkdir` failing with an error if the directory already exists. Meaning the line `mkdir -p themes && cd themes` will always end up with the shell in the `themes` directory and create it only if it has to.

As requested here: https://github.com/EvanPurkhiser/rEFInd-minimal/pull/25#issuecomment-207856376 